### PR TITLE
 Switch style/linting to chefstyle 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,0 @@
-Style/ClassAndModuleChildren:
-  Exclude:
-    - lib/busser/runner_plugin/bats.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,17 @@
 language: ruby
+cache: bundler
+dist: xenial
 
-rvm:
-  - 2.1
-  - 2.0.0
-  - 1.9.3
-  - ruby-head
-
-env:
-  - RUBYGEMS_VERSION=
-  - RUBYGEMS_VERSION=2.2.2
-  - RUBYGEMS_VERSION=2.1.11
-  - RUBYGEMS_VERSION=2.0.14
-  - RUBYGEMS_VERSION=1.8.29
-
-bundler_args: --without guard
-
-before_install:
-  - if [ -n "$RUBYGEMS_VERSION" ]; then gem update --system $RUBYGEMS_VERSION; fi
-  - gem --version
+branches:
+  only:
+  - master
 
 matrix:
-  exclude:
-    - rvm: 2.1
-      env: RUBYGEMS_VERSION=1.8.29
-    - rvm: 2.0.0
-      env: RUBYGEMS_VERSION=1.8.29
+  include:
+    - rvm: 2.4.9
+    - rvm: 2.5.7
+    - rvm: 2.6.5
+    - rvm: 2.7.0
     - rvm: ruby-head
-      env: RUBYGEMS_VERSION=1.8.29
   allow_failures:
-    - rvm: ruby-head
-
-notifications:
-  irc: "chat.freenode.net#kitchenci"
+  - rvm: ruby-head

--- a/Guardfile
+++ b/Guardfile
@@ -2,10 +2,10 @@
 ignore %r{^\.gem/}
 
 def rubocop_opts
-  { :all_on_start => false, :keep_failed => false, :cli => "-r finstyle -D" }
+  { all_on_start: false, keep_failed: false, cli: "-r chefstyle -D" }
 end
 
-group :red_green_refactor, :halt_on_fail => true do
+group :red_green_refactor, halt_on_fail: true do
   guard :cucumber do
     watch(%r{^features/.+\.feature$})
     watch(%r{^features/support/.+$}) { "features" }
@@ -15,12 +15,12 @@ group :red_green_refactor, :halt_on_fail => true do
   end
 
   guard :rubocop, rubocop_opts do
-    watch(%r{.+\.rb$})
+    watch(/.+\.rb$/)
     watch(%r{(?:.+/)?\.rubocop\.yml$}) { |m| File.dirname(m[0]) }
   end
 
   guard :cane do
-    watch(%r{.*\.rb})
+    watch(/.*\.rb/)
     watch(".cane")
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -54,10 +54,14 @@ RuboCop::RakeTask.new(:style) do |task|
   task.options << "--display-cop-names"
 end
 
-require "cane/rake_task"
-desc "Run cane to check quality metrics"
-Cane::RakeTask.new do |cane|
-  cane.canefile = "./.cane"
+require "chefstyle"
+require "rspec/core/rake_task"
+
+desc "Run RuboCop on the lib directory"
+RuboCop::RakeTask.new(:rubocop) do |task|
+  task.patterns = ["lib/**/*.rb"]
+  # don't abort rake on failure
+  task.fail_on_error = false
 end
 
 desc "Display LOC stats"
@@ -69,6 +73,6 @@ task :stats do
 end
 
 desc "Run all quality tasks"
-task :quality => [:cane, :style, :stats]
+task :quality => [:rubocop, :style, :stats]
 
 task :default => [:test, :quality]

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ namespace :bats do
   vendor = "vendor/bats"
 
   desc "Vendors bats #{version} source code into gem codebase"
-  task :vendor => "#{vendor}/VERSION.txt"
+  task vendor: "#{vendor}/VERSION.txt"
 
   directory File.dirname(tarball)
   directory vendor
@@ -46,19 +46,13 @@ Cucumber::Rake::Task.new(:features) do |t|
 end
 
 desc "Run all test suites"
-task :test => [:features]
-
-require "finstyle"
-require "rubocop/rake_task"
-RuboCop::RakeTask.new(:style) do |task|
-  task.options << "--display-cop-names"
-end
+task test: [:features]
 
 require "chefstyle"
-require "rspec/core/rake_task"
+require "rubocop/rake_task"
 
-desc "Run RuboCop on the lib directory"
-RuboCop::RakeTask.new(:rubocop) do |task|
+desc "Run Chefstyle on the lib directory"
+RuboCop::RakeTask.new(:style) do |task|
   task.patterns = ["lib/**/*.rb"]
   # don't abort rake on failure
   task.fail_on_error = false
@@ -73,6 +67,6 @@ task :stats do
 end
 
 desc "Run all quality tasks"
-task :quality => [:rubocop, :style, :stats]
+task quality: %i{rubocop style stats}
 
-task :default => [:test, :quality]
+task default: %i{test quality}

--- a/busser-bats.gemspec
+++ b/busser-bats.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "busser"
 
   gem.add_development_dependency "aruba"
-  gem.add_development_dependency "bundler", "~> 1.3"
+  gem.add_development_dependency "bundler"
   gem.add_development_dependency "countloc"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "simplecov"
@@ -30,6 +30,5 @@ Gem::Specification.new do |gem|
   # style and complexity libraries are tightly version pinned as newer releases
   # may introduce new and undesireable style choices which would be immediately
   # enforced in CI
-  gem.add_development_dependency "finstyle",  "1.2.0"
-  gem.add_development_dependency "cane",      "2.6.2"
+  gem.add_development_dependency "chefstyle",  "0.14"
 end

--- a/busser-bats.gemspec
+++ b/busser-bats.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |gem|
   # style and complexity libraries are tightly version pinned as newer releases
   # may introduce new and undesireable style choices which would be immediately
   # enforced in CI
-  gem.add_development_dependency "chefstyle",  "0.14"
+  gem.add_development_dependency "chefstyle", "0.14"
 end

--- a/lib/busser/bats/version.rb
+++ b/lib/busser/bats/version.rb
@@ -21,6 +21,6 @@ module Busser
   module Bats
 
     # Version string for the Bats Busser runner plugin
-    VERSION = "0.3.1.dev"
+    VERSION = "0.3.1.dev".freeze
   end
 end


### PR DESCRIPTION
Remove cane / finstyle and use chefstyle instead. Update the ruby
versions in Travis and remove the bundler version pin.

Signed-off-by: Tim Smith <tsmith@chef.io>