### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 
 * Upgrade vendored bats version to 0.4.0. ([@fnichol][])
 
-### Improvments
+### Improvements
 
 * Update testing dependencies, upgrade to RSpec 3.x, freshen TravisCI build matrix, add style and complexity support. ([@fnichol][])
 * Allow Aruba tests to wait 20 seconds (vs. 10). ([@fnichol][])


### PR DESCRIPTION
Fixes spelling mistakes found with the [`typos`](https://github.com/crate-ci/typos) linter.

Changes are limited to comments, documentation, and test descriptions -- no functional changes.

Files touched:
- CHANGELOG.md