### PR TITLE
ci: fail the release when the gem does not reach RubyGems

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,3 +43,25 @@ jobs:
         uses: actionshub/publish-gem-to-rubygems@f9126f7a2d36a4fd31a13e78fde5fbdcc4b7b251  # v2.0.6
         with:
           token: ${{ secrets.RUBYGEMS_API_KEY }}
+
+      # actionshub/publish-gem-to-rubygems logs a rejected push and still exits
+      # 0, so a release that never reached RubyGems shows up as a green job.
+      # Ask RubyGems directly instead of trusting the step. The v2 endpoint is
+      # 404 until the exact version is indexed, so -f turns "not there" into a
+      # non-zero exit rather than a substring match on `gem list` output.
+      - name: Verify the release reached RubyGems
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          name="$(basename "$(ls ./*.gemspec)" .gemspec)"
+          for _ in $(seq 1 12); do
+            if curl -fsS -o /dev/null "https://rubygems.org/api/v2/rubygems/${name}/versions/${VERSION}.json"; then
+              echo "${name} ${VERSION} is on RubyGems"
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "::error::${name} ${VERSION} never reached RubyGems. A permissions failure in the push step above does not fail that step -- read its log."
+          exit 1


### PR DESCRIPTION
The `actionshub/publish-gem-to-rubygems` step logs a rejected push and still
exits 0, so a release that never got published shows up as a green job.

busser-bash hit exactly that an hour ago: `v0.2.0` was tagged, the GitHub
release was cut, GitHub Packages got the gem, the workflow went green, and
RubyGems still has 0.1.4. The push had been rejected with
`You do not have permission to push to this gem`, in a step that reported
success.

busser-bats itself published 0.6.0 correctly, so this is a guard rather than a
fix for a current break here — but the failure mode is silent and shared across
all six busser plugins, so it is worth catching everywhere.

Asks RubyGems whether the version is actually there. The v2 versions endpoint
404s until that exact version is indexed, so `curl -f` turns "not there" into a
non-zero exit without the substring matching a `gem list | grep` would need
(where `0.2.0` would also match `10.2.0`).