### PR TITLE
docs: rewrite the readme and add a contributing guide

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,7 @@
+{
+  "fix": false,
+  "globs": ["**/*.md", "!vendor"],
+//   "ignores": ["ignore*.md"],
+  "noProgress": false,
+  "showFound": true
+}

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,7 +1,0 @@
-{
-  "fix": false,
-  "globs": ["**/*.md", "!vendor"],
-//   "ignores": ["ignore*.md"],
-  "noProgress": false,
-  "showFound": true
-}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - cookstyle/chefstyle
 
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
   Exclude:
     - "vendor/**/*"
     - "spec/**/*"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing to busser-bats
+
+Thanks for taking the time to contribute. This document covers how to get the
+project running locally, how to check your work before opening a pull request,
+and the commit convention releases depend on.
+
+## Getting set up
+
+This plugin requires **Ruby 3.2 or newer**. Clone the repository and install the
+development dependencies:
+
+```bash
+git clone https://github.com/test-kitchen/busser-bats.git
+cd busser-bats
+bundle install
+```
+
+## Running the tests
+
+`rake` runs the whole suite:
+
+```bash
+bundle exec rake test
+```
+
+The tests are [cucumber](https://cucumber.io) features in `features/`. They
+drive the real `busser` executable through
+[aruba](https://github.com/cucumber/aruba) rather than calling the plugin's
+classes, so they cover it end to end: install the plugin into a throwaway
+Busser root, write a suite, run it, and check what came out. The step
+definitions they use are published by busser itself, in `lib/busser/cucumber.rb`.
+
+## Linting
+
+CI runs three linters, all of which you can run locally:
+
+```bash
+bundle exec cookstyle --chefstyle   # Ruby
+yamllint --strict .                 # YAML
+markdownlint-cli2 "**/*.md" "!**/CHANGELOG*.md"
+```
+
+## Commit messages
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org).
+Releases are automated, and the commit subject on `main` is what decides the
+next version number and what appears in the changelog.
+
+Pull requests are **squash merged, so the pull request title becomes that
+subject**. A CI check enforces the format on the title; the individual commits
+on your branch are not checked.
+
+| Prefix | Effect on the next release |
+| --- | --- |
+| `fix:` | Patch version bump |
+| `feat:` | Minor version bump |
+| `feat!:`, or a `BREAKING CHANGE:` footer | Minor bump, until this gem reaches 1.0 |
+| `chore:`, `docs:`, `ci:`, `test:`, `refactor:` | No release |
+
+For example:
+
+```text
+fix: install the plugin into GEM_HOME rather than the bundle
+feat: support a Gemfile alongside the suite
+ci: pin the shared workflow to a release
+```
+
+## Opening a pull request
+
+1. Fork the repository and create a branch for your change.
+2. Add or update tests. A bug fix should come with a test that fails without it.
+3. Run `bundle exec rake test` and the linters above.
+4. Open a pull request with a Conventional Commits title.
+
+## Releases
+
+Releases are handled by
+[release-please](https://github.com/googleapis/release-please). It watches
+commits landing on `main` and keeps a release pull request open with the next
+version number and the accumulated changelog. Merging that pull request tags the
+release and publishes the gem to RubyGems and GitHub Packages.
+
+Maintainers do not bump `lib/busser/bats/version.rb` or edit
+`CHANGELOG.md` by hand; release-please owns both files. This gem is still pre-1.0, so
+`bump-minor-pre-major` is set and a breaking change takes the minor rather than
+graduating it to 1.0.

--- a/Gemfile
+++ b/Gemfile
@@ -3,16 +3,16 @@ source "https://rubygems.org"
 gemspec
 
 group :cookstyle do
-  gem "cookstyle", ">= 9.0.0"
+  gem "cookstyle", ">= 9.0"
 end
 
 group :test do
-  gem "aruba", ">= 2.0"
-  gem "base64" # cucumber needs it; not a default gem on Ruby 4.0
+  gem "aruba", ">= 2.4"
+  gem "base64", ">= 0.3" # cucumber needs it; not a default gem on Ruby 4.0
   gem "cucumber", ">= 11.1"
-  gem "rake", ">= 11.0"
+  gem "rake", ">= 13.4"
 end
 
 group :development do
-  gem "simplecov"
+  gem "simplecov", ">= 1.1"
 end

--- a/README.md
+++ b/README.md
@@ -1,50 +1,76 @@
-# Busser::RunnerPlugin::Bats
+# busser-bats
 
-[![Gem Version](https://badge.fury.io/rb/busser-bats.svg)](http://badge.fury.io/rb/busser-bats)
+[![Gem Version](https://badge.fury.io/rb/busser-bats.svg)](https://badge.fury.io/rb/busser-bats)
 
-A Busser runner plugin for [Bats][bats_site]
+A [Busser](https://github.com/test-kitchen/busser) runner plugin that runs
+[Bats](https://github.com/bats-core/bats-core) test files.
+
+Bats is a TAP-producing test harness for bash. This plugin vendors a copy of it,
+installs that copy onto the machine under test during postinstall, and then runs
+it against the suite's `bats` directory — so the machine under test needs
+nothing beyond bash.
 
 ## Status
 
-This software project is no longer under active development as it has no active maintainers. The software may continue to work for some or all use cases, but issues filed in GitHub will most likely not be triaged. If a new maintainer is interested in working on this project please come chat with us in #test-kitchen on Chef Community Slack.
+This software project is no longer under active development as it has no active
+maintainers. The software may continue to work for some or all use cases, but
+issues filed in GitHub will most likely not be triaged. If a new maintainer is
+interested in working on this project please come chat with us in #test-kitchen
+on Chef Community Slack.
 
-## Installation and Setup
+## Requirements
 
-Until proper reference documentation is complete, the [Writing a Test](https://kitchen.ci/docs/writing-test) section of the Test Kitchen's [Getting Started Guide](https://kitchen.ci/docs/) gives a working example of creating a bats test.
+Ruby 3.2 or newer, and busser 0.9.0 or newer.
+
+## Installation
+
+Busser installs the plugin for you when Test Kitchen runs the suite, so there is
+usually nothing to do. To install it by hand:
+
+```bash
+busser plugin install busser-bats
+```
 
 ## Usage
 
-**TODO:** Write documentation explaining the structure/format of testing files.
+Put your `.bats` files in the `bats` directory of a suite:
 
-## Development
+```text
+test
+`-- integration
+    `-- default          # suite name
+        `-- bats
+            `-- default.bats
+```
 
-* Source hosted at [GitHub][repo]
-* Report issues/questions/feature requests on [GitHub Issues][issues]
+The whole directory is handed to `bats`, which picks up every `*.bats` file in
+it. A test is a `@test` block, and it passes when every command in it succeeds:
 
-Pull requests are very welcome! Make sure your patches are well tested.
-Ideally create a topic branch for every separate change you make. For
-example:
+```bash
+@test "foobar.txt was created" {
+  run cat /usr/local/foobar.txt
+  [ "$status" -eq 0 ]
+  [ "$output" = "hello" ]
+}
+```
 
-1. Fork the repo
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Added some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request
+See the [Bats documentation](https://bats-core.readthedocs.io) for the full
+assertion and helper vocabulary.
 
-## Authors
+Test Kitchen picks the plugin up from the suite directory name — no verifier
+configuration is needed beyond the default busser verifier.
 
-Created and maintained by [Fletcher Nichol][author] (<fnichol@nichol.ca>)
+## Contributing
+
+Bug reports and pull requests are welcome. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for how to set up the project, run the test
+suite, and format your commits.
 
 ## License
 
-Apache 2.0 (see [LICENSE][license])
+Apache License 2.0. See [LICENSE](LICENSE).
 
-[Bats][bats_site] is released under an MIT-style license, copyright Sam Stephenson.
+The vendored copy of Bats is released under an MIT-style license, copyright Sam
+Stephenson and the bats-core contributors.
 
-
-[author]:           https://github.com/fnichol
-[issues]:           https://github.com/fnichol/busser-bats/issues
-[license]:          https://github.com/fnichol/busser-bats/blob/master/LICENSE
-[repo]:             https://github.com/fnichol/busser-bats
-
-[bats_site]:  https://github.com/sstephenson/bats
+Originally created by [Fletcher Nichol](https://github.com/fnichol).

--- a/Rakefile
+++ b/Rakefile
@@ -37,7 +37,7 @@ end
 
 require "cucumber/rake/task"
 Cucumber::Rake::Task.new(:features) do |t|
-  t.cucumber_opts = ["features", "-x", "--format progress"]
+  t.cucumber_opts = ["features", "--format progress", "--fail-fast"]
 end
 
 desc "Run all test suites"

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -4,6 +4,10 @@ require "busser/cucumber"
 if ENV["COVERAGE"]
   require "simplecov"
   SimpleCov.command_name "features"
+  SimpleCov.start do
+    add_filter "/features/"
+    add_group "Libraries", "/lib/"
+  end
 end
 
 # aruba 2 dropped @aruba_timeout_seconds; setting it in a Before hook is a
@@ -11,11 +15,4 @@ end
 # Installing a plugin and its gems into a cold sandbox does not always fit.
 Aruba.configure do |config|
   config.exit_timeout = 60
-end
-
-After do |s|
-  # Tell Cucumber to quit after this scenario is done - if it failed.
-  # This is useful to inspect the 'tmp/aruba' directory before any other
-  # steps are executed and clear it out.
-  Cucumber.wants_to_quit = true if s.failed?
 end


### PR DESCRIPTION
The README was a mix of usage docs and a generic fork-and-branch section, with
links still pointing at pre-transfer repositories and `master`. It is now just
what a user of the plugin needs: what it does, what it requires, where tests go,
and what a passing test looks like. Everything a contributor needs moved to a
new CONTRIBUTING.md, modelled on the one in test-kitchen/busser -- how to set the
project up, how to run the suite, the linters CI runs, and the Conventional
Commits convention release-please reads.

Every development dependency now carries a version floor at its current major,
so a resolver cannot quietly pick an ancient release: cookstyle 9, aruba 2.4,
cucumber 11.1, rake 13.4, simplecov 1.1.

Test tooling brought up to date:

* `.rubocop.yml` targeted Ruby 3.1 while the gemspec requires 3.2.
* The `After` hook setting `Cucumber.wants_to_quit` is replaced by cucumber's
  own `--fail-fast`, which is the supported way to stop at the first failure.
* `-x` (`--expand`) is dropped; it only affects Scenario Outline output and
  there are no outlines here.

The README documented Bats as sstephenson/bats, which has been archived for
years; it now points at bats-core, where the project actually lives. The
vendored tree itself is left alone -- #33 is already migrating it.

`.markdownlint-cli2.jsonc` is kept. I removed it first on the assumption that
the shared workflow's `globs` input overrode the config's, leaving it inert --
markdownlint-cli2 combines the two, and its `"!vendor"` entry is the only thing
keeping the vendored Bats docs out of the lint. CI caught it; the file is back.

`.simplecov` is removed: SimpleCov auto-loads it on require and started a "gem"
profile there, while env.rb separately set a command name, so which profile
applied depended on load order. The whole thing is now in env.rb behind
COVERAGE.
