### PR TITLE
chore: remove code coverage entirely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 Gemfile.lock
 InstalledFiles
 _yardoc
-coverage
 doc/
 lib/bundler/man
 pkg

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,3 @@ group :test do
   gem "cucumber", ">= 11.1"
   gem "rake", ">= 13.4"
 end
-
-group :development do
-  gem "simplecov", ">= 1.1"
-end

--- a/config/features/support/env.rb
+++ b/config/features/support/env.rb
@@ -1,11 +1,6 @@
 require "aruba/cucumber"
 require "busser/cucumber"
 
-if ENV["COVERAGE"]
-  require "simplecov"
-  SimpleCov.command_name "features"
-end
-
 Before do
   @aruba_timeout_seconds = 20
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,15 +1,6 @@
 require "aruba/cucumber"
 require "busser/cucumber"
 
-if ENV["COVERAGE"]
-  require "simplecov"
-  SimpleCov.command_name "features"
-  SimpleCov.start do
-    add_filter "/features/"
-    add_group "Libraries", "/lib/"
-  end
-end
-
 # aruba 2 dropped @aruba_timeout_seconds; setting it in a Before hook is a
 # no-op, which quietly left these commands on aruba's 15 second default.
 # Installing a plugin and its gems into a cold sandbox does not always fit.


### PR DESCRIPTION
chore: remove code coverage entirely

Nothing consumed it. Coverage only ran when COVERAGE was set in the
environment, no CI job set it, the coveralls integration that once reported the
numbers is long gone, and these plugins are small enough that a percentage was
never going to drive a decision. What was left was a dependency and a block of
setup that had to be kept working for no return.

Removed: the simplecov development dependency, the COVERAGE block in
features/support/env.rb, and the coverage entry in .gitignore now that nothing
writes that directory.