### PR TITLE
chore: drop the dead rubocop exclusions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,3 @@ require:
 
 AllCops:
   TargetRubyVersion: 3.2
-  Exclude:
-    - "vendor/**/*"
-    - "spec/**/*"


### PR DESCRIPTION
chore: drop the dead rubocop exclusions

None of them were doing anything, and each one was a place a real offence could
hide later.

* `spec/**/*` — there is no `spec/` directory in this repository.
* `vendor/**/*` — RuboCop already excludes `vendor/**/*` by default, along with
  `tmp`, `node_modules` and `.git`, so the entry was a restatement.

Verified rather than assumed: `cookstyle --chefstyle` inspects the same number of
files before and after, and still reports no offences.