### PR TITLE
fix: cover the bats command construction + resolve discoverd bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,7 @@ group :test do
   gem "aruba", ">= 2.4"
   gem "base64", ">= 0.3" # cucumber needs it; not a default gem on Ruby 4.0
   gem "cucumber", ">= 11.1"
+  gem "minitest", ">= 6.0"
+  gem "mocha", ">= 2.7"
   gem "rake", ">= 13.4"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -35,12 +35,19 @@ namespace :bats do
   end
 end
 
+require "rake/testtask"
+Rake::TestTask.new(:unit) do |t|
+  t.libs.push "lib"
+  t.test_files = FileList["spec/**/*_spec.rb"]
+  t.verbose = true
+end
+
 require "cucumber/rake/task"
 Cucumber::Rake::Task.new(:features) do |t|
   t.cucumber_opts = ["features", "--format progress", "--fail-fast"]
 end
 
 desc "Run all test suites"
-task test: [:features]
+task test: %i{unit features}
 
 task default: %i{test}

--- a/lib/busser/runner_plugin/bats.rb
+++ b/lib/busser/runner_plugin/bats.rb
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 require "pathname" unless defined?(Pathname)
+require "shellwords" unless defined?(Shellwords)
 
 require "busser/runner_plugin"
 
@@ -32,7 +33,23 @@ class Busser::RunnerPlugin::Bats < Busser::RunnerPlugin::Base
     end
   end
 
+  # Builds the bats invocation.
+  #
+  # Both paths are quoted: the Busser root is user supplied through
+  # BUSSER_ROOT, and an unquoted path containing a space would be split into
+  # two arguments by the shell and silently run the wrong thing.
+  #
+  # @param bats_bin [String, Pathname] the vendored bats executable
+  # @param suite [String, Pathname] the suite directory holding the .bats files
+  # @return [String] the command to run
+  def self.command_for(bats_bin, suite)
+    %{#{Shellwords.escape(bats_bin.to_s)} #{Shellwords.escape(suite.to_s)}}
+  end
+
+  # Runs the suite's .bats files through the vendored bats.
+  #
+  # @return [void]
   def test
-    run!("#{vendor_path("bats").join("bin/bats")} #{suite_path("bats")}")
+    run!(self.class.command_for(vendor_path("bats").join("bin/bats"), suite_path("bats")))
   end
 end

--- a/spec/busser/runner_plugin/bats_spec.rb
+++ b/spec/busser/runner_plugin/bats_spec.rb
@@ -1,0 +1,41 @@
+require_relative "../../spec_helper"
+
+require "shellwords"
+require "busser/runner_plugin/bats"
+
+describe Busser::RunnerPlugin::Bats do
+  describe ".command_for" do
+    it "puts the bats binary first and the suite second" do
+      cmd = Busser::RunnerPlugin::Bats.command_for("/opt/busser/vendor/bats/bin/bats",
+        "/opt/busser/suites/bats")
+
+      _(cmd).must_equal "/opt/busser/vendor/bats/bin/bats /opt/busser/suites/bats"
+    end
+
+    # BUSSER_ROOT is user supplied, and Windows-style or otherwise spaced paths
+    # do turn up. Unquoted, the shell would split the path and bats would be
+    # handed arguments nobody intended.
+    it "quotes a path containing spaces" do
+      cmd = Busser::RunnerPlugin::Bats.command_for("/opt/busser/bin/bats",
+        "/tmp/my tests/suites/bats")
+
+      # Shellwords.split is what a shell would do with this string, so this
+      # asserts the shell sees exactly two arguments rather than three.
+      _(Shellwords.split(cmd)).must_equal ["/opt/busser/bin/bats", "/tmp/my tests/suites/bats"]
+    end
+
+    it "neutralises shell metacharacters in a path" do
+      cmd = Busser::RunnerPlugin::Bats.command_for("/opt/busser/bin/bats",
+        "/tmp/a;rm -rf x/bats")
+
+      _(Shellwords.split(cmd)).must_equal ["/opt/busser/bin/bats", "/tmp/a;rm -rf x/bats"]
+    end
+
+    it "accepts Pathname arguments" do
+      cmd = Busser::RunnerPlugin::Bats.command_for(Pathname.new("/a/bats"),
+        Pathname.new("/b/suites/bats"))
+
+      _(cmd).must_equal "/a/bats /b/suites/bats"
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require "minitest/autorun"
+require "mocha/minitest"


### PR DESCRIPTION
These plugins had no unit tests at all -- every check was an end-to-end cucumber
feature that boots busser, installs a plugin into a sandbox and runs a suite.
That is the right shape for proving the plugin works, but it is slow and it
cannot easily probe the edges where regressions actually live, such as exactly
which filenames a glob selects.

This adds a `spec/` suite using minitest and mocha, matching what
test-kitchen/busser already does, and wires `rake unit` in alongside
`rake features`. `rake test` runs both. The aim is not coverage; every test here
is one that fails if a specific behaviour regresses.

Where the logic under test lived inside a script that executes on load, it moved
into a small module the script requires, so it can be exercised without running
a suite.

## The bug this found

The command was built by interpolation:

```ruby
run!("#{vendor_path("bats")...} #{suite_path("bats")}")
```

BUSSER_ROOT is user supplied. A root containing a space produced a command the
shell split into three arguments, so bats was handed a path fragment instead of
the suite. `command_for` now escapes both paths with `Shellwords`.

The tests assert on `Shellwords.split(cmd)` -- what a shell would actually see
-- rather than on the escaped string, so they check the property rather than the
escaping syntax. Reverting to interpolation fails two of them.